### PR TITLE
Set resource limit+request and break out deployment values

### DIFF
--- a/infra/los/templates/backend.yaml
+++ b/infra/los/templates/backend.yaml
@@ -34,20 +34,20 @@ spec:
               containerPort: {{ .Values.los_backend.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.los_backend.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.los_backend.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.los_backend.resources | nindent 12 }}
+      {{- with .Values.los_backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.los_backend.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.los_backend.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/infra/los/templates/frontend.yaml
+++ b/infra/los/templates/frontend.yaml
@@ -34,20 +34,20 @@ spec:
               containerPort: {{ .Values.los.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.los.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.los.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.los.resources | nindent 12 }}
+      {{- with .Values.los.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.los.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.los.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/infra/los/templates/los_database.yaml
+++ b/infra/los/templates/los_database.yaml
@@ -40,20 +40,20 @@ spec:
               containerPort: {{ .Values.los_database.port }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.los_database.resources | nindent 12 }}
       volumes:
         - name: pg-data-vol
           persistentVolumeClaim:
             claimName: {{ .Values.los_database.pvc_name }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.los_database.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.los_database.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.los_database.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/infra/los/values.yaml
+++ b/infra/los/values.yaml
@@ -1,5 +1,3 @@
-replicaCount: 1
-
 los_namespace: "los"
 
 los:
@@ -8,6 +6,24 @@ los:
     tag: helm
     pullPolicy: Always
   port: 3000
+  resources:
+    limits:
+      cpu: 512m
+      memory: 512Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 los_backend:
   image:
@@ -15,6 +31,24 @@ los_backend:
     tag: latest
     pullPolicy: Always
   port: 3000
+  resources:
+    limits:
+      cpu: 512m
+      memory: 512Mi
+    requests:
+      cpu: 64m
+      memory: 128Mi
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 los_database:
   image:
@@ -25,26 +59,19 @@ los_database:
   db_name: los
   pvc_name: "los-postgis-pvc"
   pvc_size: "3Gi"
+  resources:
+    limits:
+      cpu: 512m
+      memory: 512Mi
+    requests:
+      cpu: 64m
+      memory: 256Mi
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 nameOverride: ""
 fullnameOverride: ""
 
 podAnnotations: {}
 podLabels: {}
-
-resources: {}
-
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}


### PR DESCRIPTION
Set resource requests + limits based on current production usage as seen in el doggo.

Also, break out:
- resources
- livenessProbe:
- readinessProbe:
- nodeSelector
- tolerations
- affinity

for each deployment