### PR TITLE
Pin

### DIFF
--- a/infra/los/values.yaml
+++ b/infra/los/values.yaml
@@ -53,7 +53,7 @@ los_backend:
 los_database:
   image:
     repository: postgis/postgis
-    tag: latest
+    tag: 16-master
     pullPolicy: Always
   port: 5432
   db_name: los


### PR DESCRIPTION
Today when redeploying, unpinned postgis bumped and we got:
```
2024-10-26 17:37:55.393 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.0 (Debian 17.0-1.pgdg110+1).
```