### PR TITLE
Update 3d building data links 

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -46,7 +46,7 @@ export default function Form(props) {
 					<a
 						target="_"
 						className="dark-blue no-underline"
-						href="https://www1.nyc.gov/site/doitt/initiatives/3d-building.page"
+						href="https://www.nyc.gov/content/oti/pages/tools"
 					>
 						NYC 3D Building Model
 					</a>{" "}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -379,7 +379,7 @@ function Info({ address }) {
 				<a
 					target="_"
 					className="dark-blue no-underline"
-					href="https://www1.nyc.gov/site/doitt/initiatives/3d-building.page"
+					href="https://www.nyc.gov/content/oti/pages/tools"
 				>
 					NYC 3D Building Model
 				</a>{" "}


### PR DESCRIPTION
The link used is unfortunately outdated: https://web.archive.org/web/20220113000754/https://www1.nyc.gov/site/doitt/initiatives/3d-building.page

It was kind of hard to find what the current link is. The best appears to be here: https://www.nyc.gov/content/oti/pages/tools

Note, this seemed like the first link at first, but it is a different dataset: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-nyc-3d-model-download.page
